### PR TITLE
a couple of fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,11 +2,11 @@ NAME := licentia
 VERSION := v1.0.1
 
 build:
-	go build -ldflags "-X main.Version $(VERSION)"
+	go build -ldflags "-X main.Version=$(VERSION)"
 
 compile:
 	@rm -rf build/
-	@gox -ldflags "-X main.Version $(VERSION)" \
+	@gox -ldflags "-X main.Version=$(VERSION)" \
 	-os="darwin" \
 	-os="linux" \
 	-os="windows" \
@@ -15,7 +15,7 @@ compile:
 	./...
 
 install:
-	go install -ldflags "-X main.Version $(VERSION)"
+	go install -ldflags "-X main.Version=$(VERSION)"
 
 deps:
 	go get github.com/c4milo/github-release

--- a/licentia.go
+++ b/licentia.go
@@ -459,7 +459,7 @@ func detectLicense(filepath string) (LicenseType, error) {
 	l := license.New("", strings.TrimSpace(buf.String()))
 	l.File = filepath
 	if err = l.GuessType(); err != nil {
-		if err.Error() == license.ErrUnrecognizedLicense {
+		if err == license.ErrUnrecognizedLicense {
 			return UNKNOWN, scanner.Err()
 		}
 		return UNKNOWN, err


### PR DESCRIPTION
This PR contains two commits. One fixes a type mismatch introduced [here](https://github.com/ryanuber/go-license/pull/18) that causes the following compilation error:

```
../../go/src/github.com/c4milo/licentia/licentia.go:462: invalid operation: err.Error() == license.ErrUnrecognizedLicense (mismatched types string and error)
```

and the other updates to the new `-ldflags` format that's enforced in Go 1.7.
