### PR TITLE
update to supported go versions for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ sudo: false
 language: go
 
 go:
-  - 1.4
-  - 1.5
+  - 1.7
+  - 1.8
   - tip
 
 install:


### PR DESCRIPTION
Per the [Go release policy](https://golang.org/doc/devel/release.html#policy), the current and previous Go versions are supported by the Go team. This PR updates the Travis config accordingly.